### PR TITLE
Change to use GitHub Token rather than GitHub PAT

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -35,4 +35,4 @@ jobs:
             repository: ${{ github.repository }}
             branch: main
             workflow: tests.yml
-            token: ${{ secrets.REPO_SCOPED_TOKEN }}
+            token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,9 +8,10 @@ Changelog
     * Documentation Changes
         * Update UniversalSentenceEncoder docstring example (:pr:`42`)
     * Testing Changes
-
+        * Change from GitHub PAT to auto generated GitHub Token for dependency checker (:pr:`53`)
+        
     Thanks to the following people for contributing to this release:
-    :user:`rwedge`
+    :user:`gsheni`, :user:`rwedge`
 
 **v1.1.0** Oct 26, 2020
     * Changes


### PR DESCRIPTION
- Change from GitHub PAT to auto generated GitHub Token for dependency checker