### PR TITLE
CI tests will not cancel if other tests fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ jobs:
     name: Entry Point Test - Python ${{ matrix.python_version }} - Featuretools ${{ matrix.featuretools_version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version: ["3.7", "3.8"]
         featuretools_version: ["Release", "Main"]
@@ -36,6 +37,7 @@ jobs:
     name: Lint Tests - Python ${{ matrix.python_version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version: ["3.7", "3.8"]
     steps:
@@ -60,6 +62,7 @@ jobs:
     name: Unit Tests - Python ${{ matrix.python_version }} - Featuretools ${{ matrix.featuretools_version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version: ["3.7", "3.8"]
         featuretools_version: ["Release", "Main"]
@@ -88,6 +91,7 @@ jobs:
     name: Package Test - Python ${{ matrix.python_version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version: ["3.7", "3.8"]
     steps:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,9 +7,10 @@ Changelog
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Individual CI jobs will not cancel if other jobs fail (:pr:`67`)
 
     Thanks to the following people for contributing to this release:
-    ...
+    :user:`rwedge`
 
 **v1.2.0** Sept 3, 2021
     * Enhancements


### PR DESCRIPTION
Updates the github actions so that if a specific github action test fails, it does not cause the other tests to cancel.