### PR TITLE
Update scheduler to use correct workflow name

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -16,7 +16,7 @@ jobs:
             task: is_workflow_success
             repository: ${{ github.repository }}
             branch: main
-            workflow: Tests
+            workflow: Unit Tests - Latest Dependencies
 
         - name: Check for recent commit to Featuretools
           if: ${{ steps.is_workflow_success.outputs.value == 'True' }}


### PR DESCRIPTION
- We got an error from the last run:
  - https://github.com/alteryx/nlp_primitives/runs/4609622401?check_suite_focus=true
```
  File "/ci/github/api.py", line 73, in is_workflow_success
    raise ValueError(info)
ValueError: no workflow found for "Tests"
```
