### PR TITLE
Conditionally add tensorflow dependent primitives to top level primitives

### DIFF
--- a/.github/workflows/optional_primitive_test.yml
+++ b/.github/workflows/optional_primitive_test.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
 
-name: Test optional primitive availability
+name: Optional Primitive Test
 jobs:
   optional_primitive_test:
-    name: Optional Primitive Test - Python ${{ matrix.python_version }} - Featuretools ${{ matrix.featuretools_version }}
+    name: Python ${{ matrix.python_version }} - Featuretools ${{ matrix.featuretools_version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/optional_primitive_test.yml
+++ b/.github/workflows/optional_primitive_test.yml
@@ -1,0 +1,43 @@
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+
+name: Test optional primitive availability
+jobs:
+  optional_primitive_test:
+    name: Optional Primitive Test - Python ${{ matrix.python_version }} - Featuretools ${{ matrix.featuretools_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.7", "3.8", "3.9"]
+        featuretools_version: ["Release", "Main"]
+    steps:
+      - name: Set up python ${{ matrix.python_version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Install standard requirements
+        run: |
+          pip config --site set global.progress_bar off
+          make installdeps
+      - if: ${{ matrix.featuretools_version == 'Main' }}
+        name: Install latest version of Featuretools from main branch
+        run: pip install git+https://github.com/alteryx/featuretools.git@main#egg=featuretools --force-reinstall
+      - name: Test optional primitives are not imported
+        run: python -c "import nlp_primitives; assert all(p not in dir(nlp_primitives) for p in ('Elmo', 'UniversalSentenceEncoder'))"
+      - name: Install complete requirements
+        run: make installdeps-complete
+      - if: ${{ matrix.featuretools_version == 'Main' }}
+        name: Install latest version of Featuretools from main branch
+        run: pip install git+https://github.com/alteryx/featuretools.git@main#egg=featuretools --force-reinstall
+      - name: Test optional primitives are imported
+        run: python -c "import nlp_primitives; assert all(p in dir(nlp_primitives) for p in ('Elmo', 'UniversalSentenceEncoder'))"

--- a/nlp_primitives/__init__.py
+++ b/nlp_primitives/__init__.py
@@ -2,8 +2,9 @@
 import nltk.data
 
 __version__ = '2.2.0'
+from importlib.util import find_spec
+
 import pkg_resources
-import importlib
 
 from .count_string import CountString
 from .diversity_score import DiversityScore
@@ -23,7 +24,7 @@ from .total_word_length import TotalWordLength
 from .upper_case_count import UpperCaseCount
 from .whitespace_count import WhitespaceCount
 
-if importlib.util.find_spec("tensorflow"):
+if find_spec("tensorflow") and find_spec("tensorflow_hub"):
   from .universal_sentence_encoder import UniversalSentenceEncoder
 
 nltk_data_path = pkg_resources.resource_filename('nlp_primitives', 'data/nltk-data/')

--- a/nlp_primitives/__init__.py
+++ b/nlp_primitives/__init__.py
@@ -3,6 +3,7 @@ import nltk.data
 
 __version__ = '2.2.0'
 import pkg_resources
+import importlib
 
 from .count_string import CountString
 from .diversity_score import DiversityScore
@@ -21,6 +22,9 @@ from .title_word_count import TitleWordCount
 from .total_word_length import TotalWordLength
 from .upper_case_count import UpperCaseCount
 from .whitespace_count import WhitespaceCount
+
+if importlib.util.find_spec("tensorflow"):
+  from .universal_sentence_encoder import UniversalSentenceEncoder
 
 nltk_data_path = pkg_resources.resource_filename('nlp_primitives', 'data/nltk-data/')
 nltk.data.path.insert(0, nltk_data_path)

--- a/nlp_primitives/__init__.py
+++ b/nlp_primitives/__init__.py
@@ -17,15 +17,15 @@ from .part_of_speech_count import PartOfSpeechCount
 from .polarity_score import PolarityScore
 from .punctuation_count import PunctuationCount
 from .stopword_count import StopwordCount
-from .tensorflow.elmo import Elmo
-from .tensorflow.universal_sentence_encoder import UniversalSentenceEncoder
 from .title_word_count import TitleWordCount
 from .total_word_length import TotalWordLength
 from .upper_case_count import UpperCaseCount
 from .whitespace_count import WhitespaceCount
 
 if find_spec("tensorflow") and find_spec("tensorflow_hub"):
-  from .universal_sentence_encoder import UniversalSentenceEncoder
+    from .tensorflow.elmo import Elmo
+    from .tensorflow.universal_sentence_encoder import UniversalSentenceEncoder
+
 
 nltk_data_path = pkg_resources.resource_filename('nlp_primitives', 'data/nltk-data/')
 nltk.data.path.insert(0, nltk_data_path)

--- a/nlp_primitives/tests/test_universal_sentence_encoder.py
+++ b/nlp_primitives/tests/test_universal_sentence_encoder.py
@@ -11,6 +11,7 @@ from featuretools.primitives.utils import (
 from woodwork.logical_types import NaturalLanguage
 
 from ..tensorflow.universal_sentence_encoder import UniversalSentenceEncoder
+from .test_utils import PRIMITIVES
 
 
 def test_regular(universal_sentence_encoder):
@@ -25,6 +26,10 @@ def test_regular(universal_sentence_encoder):
     a = a.mean().round(7).to_numpy()
     b = pd.Series([-0.0007475, 0.0032088, 0.0018552, 0.0008256, 0.0028342])
     np.testing.assert_array_almost_equal(a, b)
+
+
+def test_name_in_primitive_list(universal_sentence_encoder):
+        assert PRIMITIVES.name.eq(universal_sentence_encoder.name).any()
 
 
 @pytest.fixture()

--- a/nlp_primitives/tests/test_universal_sentence_encoder.py
+++ b/nlp_primitives/tests/test_universal_sentence_encoder.py
@@ -29,7 +29,7 @@ def test_regular(universal_sentence_encoder):
 
 
 def test_name_in_primitive_list(universal_sentence_encoder):
-        assert PRIMITIVES.name.eq(universal_sentence_encoder.name).any()
+    assert PRIMITIVES.name.eq(universal_sentence_encoder.name).any()
 
 
 @pytest.fixture()


### PR DESCRIPTION
Uses importlib to check for a tensorflow module before adding `UniversalSentenceEncoder`  and `Elmo` to top level imports for the library