### PR TITLE
v2.3.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,17 +2,25 @@
 Changelog
 =========
 
-Future Release
-==============
+.. Future Release
+  ==============
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
-        * Skip Tensorflow dependent tests if --notensorflow flag is passed to pytest(:pr:`107`)
+
+.. Thanks to the following people for contributing to this release:
+
+v2.3.0 Feb 28, 2022
+===================
+    * Changes
+        * Tensorflow dependent primitives only imported at top level if tensorflow is installed (:pr:`105`)
+    * Testing Changes
+        * Skip Tensorflow dependent tests if --notensorflow flag is passed to pytest (:pr:`107`)
 
     Thanks to the following people for contributing to this release:
-    :user:`dvreed77`
+    :user:`dvreed77`, :user:`rwedge`
 
 v2.2.0 Feb 17, 2022
 ===================

--- a/nlp_primitives/__init__.py
+++ b/nlp_primitives/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import nltk.data
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 from importlib.util import find_spec
 
 import pkg_resources

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require = {
 
 setup(
     name='nlp_primitives',
-    version='2.2.0',
+    version='2.3.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     classifiers=[


### PR DESCRIPTION
**v2.3.0 Feb 28, 2022**

  * Changes
      * Tensorflow dependent primitives only imported at top level if tensorflow is installed (#105)
  * Testing Changes
      * Skip Tensorflow dependent tests if --notensorflow flag is passed to pytest (#107)
