### PR TITLE
Initialize LSA pipeline after initialization

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,15 +2,17 @@
 Changelog
 =========
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+        * Speed up LSA primitive initialization (:pr:`118`)
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`rwedge`
 
 v2.4.0 Mar 31, 2022
 ===================

--- a/nlp_primitives/lsa.py
+++ b/nlp_primitives/lsa.py
@@ -49,16 +49,22 @@ class LSA(TransformPrimitive):
     return_type = ColumnSchema(logical_type=Double, semantic_tags={'numeric'})
     default_value = 0
 
-    def __init__(self):
+    def __init__(self, random_seed=0):
         # TODO: allow user to use own corpus
         self.number_output_features = 2
         self.n = 2
+        self.trainer = None
+        self.random_seed = random_seed
 
+    def _create_trainer(self):
         gutenberg = nltk.corpus.gutenberg.sents()
-        self.trainer = make_pipeline(TfidfVectorizer(), TruncatedSVD())
+        svd = TruncatedSVD(random_state=self.random_seed)
+        self.trainer = make_pipeline(TfidfVectorizer(), svd)
         self.trainer.fit([" ".join(sent) for sent in gutenberg])
 
     def get_function(self):
+        if self.trainer is None:
+            self._create_trainer()
         dtk = TreebankWordDetokenizer()
 
         def lsa(array):

--- a/nlp_primitives/tests/test_lsa.py
+++ b/nlp_primitives/tests/test_lsa.py
@@ -75,4 +75,3 @@ class TestLSA(PrimitiveT):
         df2 = calculate_feature_matrix([new_feat], entityset=es)
 
         assert df1.equals(df2)
-        assert False

--- a/nlp_primitives/tests/test_lsa.py
+++ b/nlp_primitives/tests/test_lsa.py
@@ -46,7 +46,7 @@ class TestLSA(PrimitiveT):
     def test_seed(self):
         prim = self.primitive(random_seed=1)
         # trigger trainer creation via get_function
-        primitive_func = prim.get_function()
+        _ = prim.get_function()
         # trainer.steps returns list of tuples representing pipeline steps
         # tuple has form ("component_name", component_object)
         assert prim.trainer.steps[1][1].random_state == 1

--- a/nlp_primitives/tests/test_lsa.py
+++ b/nlp_primitives/tests/test_lsa.py
@@ -43,6 +43,14 @@ class TestLSA(PrimitiveT):
                                              np.concatenate(([np.array(results[0])], [np.array(results[1])]), axis=0),
                                              decimal=2)
 
+    def test_seed(self):
+        prim = self.primitive(random_seed=1)
+        # trigger trainer creation via get_function
+        primitive_func = prim.get_function()
+        # trainer.steps returns list of tuples representing pipeline steps
+        # tuple has form ("component_name", component_object)
+        assert prim.trainer.steps[1][1].random_state == 1
+
     def test_with_featuretools(self, es):
         transform, aggregation = find_applicable_primitives(self.primitive)
         primitive_instance = self.primitive()


### PR DESCRIPTION
Goal of this PR is to move the creation and/or fitting of the LSA pipeline to happen after initialization to avoid a very slow initialization

Also added a `random_seed` parameter with a default value of 0