### PR TITLE
Update install tests

### DIFF
--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -28,21 +28,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Install requirements
-        run: |
-          pip config --site set global.progress_bar off
-          pip install -r requirements.txt
-          pip install -r complete-requirements.txt
-          pip install -r test-requirements.txt
       - name: Create source distribution
         run: make package_nlp_primitives
-      - name: Install source distribution
+      - name: Install nlp_primtivies from sdist
         run: |
           NLP_PRIMITIVES_VERSION=$(python setup.py --version)
           pip install dist/nlp_primitives-${NLP_PRIMITIVES_VERSION}.tar.gz
-      - name: Run unit tests
+      - name: Test by importing
         run: |
           cd nlp_primitives
           python -c "import nlp_primitives; print(nlp_primitives.__version__)"
           python -c "import sys; print(sys.path)"
-          make -f ../Makefile unit-tests
+      - name: Check package conflicts
+        run: |
+          python -m pip check

--- a/.github/workflows/lint_check.yaml
+++ b/.github/workflows/lint_check.yaml
@@ -30,4 +30,4 @@ jobs:
           make installdeps-complete
           pip install -r test-requirements.txt
       - name: Run lint tests
-        run: make lint-tests
+        run: make lint

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -36,4 +36,4 @@ jobs:
         name: Install latest version of Featuretools from main branch
         run: pip install git+https://github.com/alteryx/featuretools.git@main#egg=featuretools --force-reinstall
       - name: Run unit tests
-        run: make unit-tests
+        run: make tests

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -36,4 +36,4 @@ jobs:
         name: Install latest version of Featuretools from main branch
         run: pip install git+https://github.com/alteryx/featuretools.git@main#egg=featuretools --force-reinstall
       - name: Run unit tests
-        run: make tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,13 @@ lint-fix:
 	autopep8 --in-place --recursive --max-line-length=100 --select=${select} nlp_primitives
 	isort --recursive nlp_primitives
 
-.PHONY: lint-tests
-lint-tests:
+.PHONY: lint
+lint:
 	flake8 nlp_primitives
 	isort --check-only nlp_primitives
 
-.PHONY: unit-tests
-unit-tests:
+.PHONY: test
+test:
 	pytest --cache-clear --show-capture=stderr -vv
 
 .PHONY: installdeps
@@ -56,8 +56,16 @@ checkdepscomplete:
 	$(eval allow_list='featuretools|nltk|tensorflow|tensorflow_hub')
 	pip freeze | grep -v "nlp_primitives.git" | grep -E $(allow_list) > $(OUTPUT_FILEPATH)
 
+.PHONY: upgradepip
+upgradepip:
+	python -m pip install --upgrade pip
+
+.PHONY: upgradebuild
+upgradebuild:
+	python -m pip install --upgrade build
+
 .PHONY: package_nlp_primitives
-package_nlp_primitives:
+package_nlp_primitives: upgradepip upgradebuild
 	python setup.py sdist
 	$(eval PACKAGE=$(shell python setup.py --version))
 	tar -zxvf "dist/nlp_primitives-${PACKAGE}.tar.gz"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,9 +10,10 @@ Future Release
         * Speed up LSA primitive initialization (:pr:`118`)
     * Documentation Changes
     * Testing Changes
+        * Fix install test and update Makefile (:pr:`123`)
 
     Thanks to the following people for contributing to this release:
-    :user:`rwedge`
+    :user:`rwedge`, :user:`thehomebrewnerd`
 
 v2.4.0 Mar 31, 2022
 ===================


### PR DESCRIPTION
Install tests were running full unit tests. This PR updates the install tests to no longer run the unit tests, but rather just build the package, install it and check that it imports properly.

Also updates Makefile command to be consistent with Featuretools: `make lint-tests` -> `make lint` and `make unit-tests` -> `make test`