### PR TITLE
v2.5.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,14 +2,22 @@
 Changelog
 =========
 
-Future Release
-==============
+.. Future Release
+  ==============
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. Thanks to the following people for contributing to this release:
+
+v2.5.0 Apr 7, 2022
+==================
     * Fixes
         * Fix ``NumUniqueSeparators`` to allow for serialization and deserialization (:pr:`122`)
     * Changes
         * Speed up LSA primitive initialization (:pr:`118`)
-    * Documentation Changes
     * Testing Changes
         * Fix install test and update Makefile (:pr:`123`)
 

--- a/nlp_primitives/__init__.py
+++ b/nlp_primitives/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import nltk.data
 
-__version__ = '2.4.0'
+__version__ = '2.5.0'
 from importlib.util import find_spec
 
 import pkg_resources

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require = {
 
 setup(
     name='nlp_primitives',
-    version='2.4.0',
+    version='2.5.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     classifiers=[


### PR DESCRIPTION
**v2.5.0 Apr 7, 2022**
* Fixes
    * Fix ``NumUniqueSeparators`` to allow for serialization and deserialization (#122)
* Changes
    * Speed up LSA primitive initialization (#118)
* Testing Changes
    * Fix install test and update Makefile (#123)