### PR TITLE
Docstring and module updates

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Future Release
     * Fixes
     * Changes
         * Transition to use pyproject.toml and setup.cfg (moving away from setup.py) (:pr:`127`, :pr:`132`)
+        * ``Elmo`` and ``UniversalSentenceEncoder`` added to the ``nlp_primitives.tensorflow`` module namespace (:pr:`150`)
     * Documentation Changes
     * Testing Changes
         * Fix latest dependency checker to create PR (:pr:`129`)

--- a/nlp_primitives/__init__.py
+++ b/nlp_primitives/__init__.py
@@ -23,8 +23,7 @@ from .upper_case_count import UpperCaseCount
 from .whitespace_count import WhitespaceCount
 
 if find_spec("tensorflow") and find_spec("tensorflow_hub"):
-    from .tensorflow.elmo import Elmo
-    from .tensorflow.universal_sentence_encoder import UniversalSentenceEncoder
+    from .tensorflow import Elmo, UniversalSentenceEncoder
 
 
 nltk_data_path = pkg_resources.resource_filename("nlp_primitives", "data/nltk-data/")

--- a/nlp_primitives/count_string.py
+++ b/nlp_primitives/count_string.py
@@ -8,6 +8,7 @@ from woodwork.logical_types import Integer, NaturalLanguage
 
 class CountString(TransformPrimitive):
     """Determines how many times a given string shows up in a text field.
+
     Args:
         string (str): The string to determine the count of. Defaults to
             the word "the".

--- a/nlp_primitives/num_unique_separators.py
+++ b/nlp_primitives/num_unique_separators.py
@@ -7,7 +7,7 @@ NATURAL_LANGUAGE_SEPARATORS = [" ", ".", ",", "!", "?", ";", "\n"]
 
 
 class NumUniqueSeparators(TransformPrimitive):
-    """Calculates the number of unique separators.
+    r"""Calculates the number of unique separators.
 
     Description:
         Given a string and a list of separators, determine
@@ -16,7 +16,7 @@ class NumUniqueSeparators(TransformPrimitive):
 
     Args:
         separators (list, optional): a list of separator characters to count.
-            `[`" ", ".", ",", "!", "?", ";", "\n"]` is used by default.
+            ``[" ", ".", ",", "!", "?", ";", "\n"]`` is used by default.
 
     Examples:
         >>> x = ["First. Line.", "This. is the second, line!", "notinlist@#$%^%&"]

--- a/nlp_primitives/number_of_common_words.py
+++ b/nlp_primitives/number_of_common_words.py
@@ -10,6 +10,7 @@ from .constants import common_words_1000
 
 class NumberOfCommonWords(TransformPrimitive):
     """Determines the number of common words in a string.
+
     Description:
         Given string, determine the number of words that appear in a supplied word set.
         The word set defaults to nlp_primitives.constants.common_words_1000. The string

--- a/nlp_primitives/tensorflow/__init__.py
+++ b/nlp_primitives/tensorflow/__init__.py
@@ -1,2 +1,3 @@
+# flake8: noqa
 from .elmo import Elmo
 from .universal_sentence_encoder import UniversalSentenceEncoder

--- a/nlp_primitives/tensorflow/__init__.py
+++ b/nlp_primitives/tensorflow/__init__.py
@@ -1,0 +1,2 @@
+from .elmo import Elmo
+from .universal_sentence_encoder import UniversalSentenceEncoder


### PR DESCRIPTION
* Makes `Elmo` and `UniversalSentenceEncoder` accessible in the `nlp_primitives.tensorflow` space.  It's easy for the docs to then point at that submodule and get all the tensorflow primitives.
* Updates the syntax of some docstrings that were causing warnings when building the docs