### PR TITLE
Remove test duplication in CI

### DIFF
--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -37,7 +37,7 @@ jobs:
           make installdeps-test
           pip install git+https://github.com/alteryx/featuretools.git@main#egg=featuretools --force-reinstall
       - if: ${{ matrix.featuretools_version == 'Release' }}
-        name: Install latest version of Featuretools from main branch
+        name: Install latest version of Featuretools from PyPI
         run: |
           make installdeps-complete
           make installdeps-test

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -41,11 +41,11 @@ jobs:
         run: |
           make installdeps-complete
           make installdeps-test
-      - if: ${{ matrix.python_version != 3.7 || matrix.featuretools_version != 'main' }}
+      - if: ${{ matrix.python_version != 3.7 && matrix.featuretools_version != 'main' }}
         name: Run unit tests with no code coverage
         run: |
           make test
-      - if: ${{ matrix.python_version == 3.7 || matrix.featuretools_version == 'main' }}
+      - if: ${{ matrix.python_version == 3.7 && matrix.featuretools_version == 'main' }}
         name: Run unit tests with code coverage
         run: |
           make testcoverage

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           make installdeps-complete
           make installdeps-test
-      - if: ${{ matrix.python_version != 3.7 && matrix.featuretools_version != 'main' }}
+      - if: ${{ matrix.python_version != 3.7 || matrix.featuretools_version != 'main' }}
         name: Run unit tests with no code coverage
         run: |
           make test

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,7 @@ Future Release
     * Documentation Changes
     * Testing Changes
         * Fix latest dependency checker to create PR (:pr:`129`)
+        * Fixed unit tests workflow test choice logic (:pr:`151`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`rwedge`


### PR DESCRIPTION
Some workflows are running unit tests with code coverage and without due to a flaw in the workflow logic