### PR TITLE
Update release branch naming instructions in release.md

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,15 +2,17 @@
 Changelog
 =========
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
+        * Update release branch naming convention in documentation (:pr:`155`)
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`rwedge`
 
 v2.6.0 Jun 16, 2022
 ===================

--- a/release.md
+++ b/release.md
@@ -3,7 +3,7 @@
 ## Create nlp_primitives release on Github
 
 #### Create release branch
-1. Branch off of main and name the branch the release version number (e.g. v0.4.0)
+1. Branch off of main. For the branch name, please use "release_vX.Y.Z" as the naming scheme (e.g. "release_v0.13.3"). Doing so will bypass our release notes checkin test which requires all other PRs to add a release note entry.
 
 #### Bump version number
 2. Bump verison number in `nlp_primitives/version.py` and `nlp_primitives/tests/test_version.py`.


### PR DESCRIPTION
The existing naming recommendation does not pass the release notes check. See #153 