### PR TITLE
Fix LSA naming

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,15 +2,17 @@
 Changelog
 =========
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
+        * Clean up naming of LSA features to prevent full custom corpus from being displayed (:pr:`161`)
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 v2.7.0 Jun 16, 2022
 ===================

--- a/nlp_primitives/lsa.py
+++ b/nlp_primitives/lsa.py
@@ -78,13 +78,13 @@ class LSA(TransformPrimitive):
     return_type = ColumnSchema(logical_type=Double, semantic_tags={"numeric"})
     default_value = 0
 
-    def __init__(self, random_seed=0, corpus=None, algorithm=None):
+    def __init__(self, random_seed=0, corpus=None, algorithm="randomized"):
         self.number_output_features = 2
         self.n = 2
         self.trainer = None
         self.random_seed = random_seed
         self.corpus = corpus
-        self.algorithm = algorithm or "randomized"
+        self.algorithm = algorithm
         if self.algorithm not in ["randomized", "arpack"]:
             raise ValueError(
                 "TruncatedSVD algorithm must be either 'randomized' or 'arpack'"
@@ -121,3 +121,21 @@ class LSA(TransformPrimitive):
             return pd.Series(arr)
 
         return lsa
+
+    def get_args_string(self):
+        # Override base class method to prevent full custom corpus from being
+        # displayed in primitive arguments
+        strings = []
+        for name, value in self.get_arguments():
+            # format arg to string
+            if name == "corpus":
+                value = "user_defined"
+            string = "{}={}".format(name, str(value))
+            strings.append(string)
+
+        if len(strings) == 0:
+            return ""
+
+        string = ", ".join(strings)
+        string = ", " + string
+        return string

--- a/nlp_primitives/tests/test_lsa.py
+++ b/nlp_primitives/tests/test_lsa.py
@@ -109,3 +109,17 @@ class TestLSA(PrimitiveT):
         err_message = "TruncatedSVD algorithm must be either 'randomized' or 'arpack'"
         with pytest.raises(ValueError, match=err_message):
             LSA(algorithm="bad_algo")
+
+    def test_args_strings(self):
+        # With default values args string should be empty
+        args_string = self.primitive().get_args_string()
+        assert args_string == ""
+
+        # Should include arpack
+        args_string = self.primitive(algorithm="arpack").get_args_string()
+        assert args_string == ", algorithm=arpack"
+
+        # Should display "user_defined" instead of full custom corpus
+        custom_corpus = ["I", "am", "a", "custom", "corpus"]
+        args_string = self.primitive(corpus=custom_corpus).get_args_string()
+        assert args_string == ", corpus=user_defined"

--- a/nlp_primitives/tests/test_lsa.py
+++ b/nlp_primitives/tests/test_lsa.py
@@ -123,3 +123,9 @@ class TestLSA(PrimitiveT):
         custom_corpus = ["I", "am", "a", "custom", "corpus"]
         args_string = self.primitive(corpus=custom_corpus).get_args_string()
         assert args_string == ", corpus=user_defined"
+
+        # Test all args
+        args_string = self.primitive(
+            random_seed=100, corpus=custom_corpus, algorithm="arpack"
+        ).get_args_string()
+        assert args_string == ", random_seed=100, corpus=user_defined, algorithm=arpack"


### PR DESCRIPTION
Overrides the `get_args_string` method to avoid displaying a full user-defined custom corpus in the feature name and instead just displays `corpus=user_defined` instead.

Also updates the algorithm default value to `randomized` instead of `None` to prevent it from always being displayed in feature name.