### PR TITLE
Refactor Primitives to use Count String

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 Future Release
 ==============
     * Enhancements
+        * Change `TitleWordCount`, `PunctuationCount` to use `CountString` (:pr:`183`)
     * Fixes
         * Update README.md with Alteryx info (:pr:`167`)
     * Changes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 Future Release
 ==============
     * Enhancements
-        * Change `TitleWordCount`, `PunctuationCount` to use `CountString` (:pr:`183`)
+        * Change `TitleWordCount`, `PunctuationCount`, `UpperCaseCount` to use `CountString` (:pr:`183`)
     * Fixes
         * Update README.md with Alteryx info (:pr:`167`)
     * Changes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,13 +5,13 @@ Changelog
 Future Release
 ==============
     * Enhancements
-        * Change `TitleWordCount`, `PunctuationCount`, `UpperCaseCount` to use `CountString` (:pr:`183`)
     * Fixes
         * Update README.md with Alteryx info (:pr:`167`)
     * Changes
         * Add Woodwork as core dependency (:pr:`170`)
         * Add support for Python 3.10 (:pr:`175`)
         * Drop support for Python 3.7 (:pr:`176`)
+        * Change `TitleWordCount`, `PunctuationCount`, `UpperCaseCount` to use `CountString` (:pr:`183`)
     * Documentation Changes
     * Testing Changes
 

--- a/nlp_primitives/punctuation_count.py
+++ b/nlp_primitives/punctuation_count.py
@@ -4,7 +4,7 @@ import re
 import string
 
 from woodwork.column_schema import ColumnSchema
-from woodwork.logical_types import Double, NaturalLanguage
+from woodwork.logical_types import IntegerNullable, NaturalLanguage
 
 from .count_string import CountString
 

--- a/nlp_primitives/punctuation_count.py
+++ b/nlp_primitives/punctuation_count.py
@@ -29,7 +29,7 @@ class PunctuationCount(CountString):
 
     name = "punctuation_count"
     input_types = [ColumnSchema(logical_type=NaturalLanguage)]
-    return_type = ColumnSchema(logical_type=Double, semantic_tags={"numeric"})
+    return_type = ColumnSchema(logical_type=IntegerNullable, semantic_tags={"numeric"})
     default_value = 0
 
     def __init__(self):

--- a/nlp_primitives/punctuation_count.py
+++ b/nlp_primitives/punctuation_count.py
@@ -3,13 +3,13 @@
 import re
 import string
 
-import numpy as np
-from featuretools.primitives.base import TransformPrimitive
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Double, NaturalLanguage
 
+from .count_string import CountString
 
-class PunctuationCount(TransformPrimitive):
+
+class PunctuationCount(CountString):
     """Determines number of punctuation characters in a string.
 
     Description:
@@ -32,14 +32,6 @@ class PunctuationCount(TransformPrimitive):
     return_type = ColumnSchema(logical_type=Double, semantic_tags={"numeric"})
     default_value = 0
 
-    def get_function(self):
+    def __init__(self):
         pattern = "(%s)" % "|".join([re.escape(x) for x in string.punctuation])
-
-        def punctuation_count(x):
-            x = x.reset_index(drop=True)
-            counts = x.str.extractall(pattern).groupby(level=0).count()[0]
-            counts = counts.reindex_like(x).fillna(0)
-            counts[x.isnull()] = np.nan
-            return counts.astype(float)
-
-        return punctuation_count
+        super().__init__(string=pattern, is_regex=True, ignore_case=False)

--- a/nlp_primitives/tests/test_punctuation_count.py
+++ b/nlp_primitives/tests/test_punctuation_count.py
@@ -19,8 +19,8 @@ class TestPunctuationCount(PrimitiveT):
             ]
         )
         primitive_func = self.primitive().get_function()
-        answers = pd.Series([1.0, 2.0, 4.0, 6.0, 4.0])
-        pd.testing.assert_series_equal(primitive_func(x), answers, check_names=False)
+        answers = [1.0, 2.0, 4.0, 6.0, 4.0]
+        np.testing.assert_array_equal(primitive_func(x), answers)
 
     def test_multiline(self):
         x = pd.Series(
@@ -30,14 +30,14 @@ class TestPunctuationCount(PrimitiveT):
             ]
         )
         primitive_func = self.primitive().get_function()
-        answers = pd.Series([1.0, 2.0])
-        pd.testing.assert_series_equal(primitive_func(x), answers, check_names=False)
+        answers = [1.0, 2.0]
+        np.testing.assert_array_equal(primitive_func(x), answers)
 
     def test_nan(self):
         x = pd.Series([np.nan, "", "This is a test file."])
         primitive_func = self.primitive().get_function()
-        answers = pd.Series([np.nan, 0.0, 1.0])
-        pd.testing.assert_series_equal(primitive_func(x), answers, check_names=False)
+        answers = [np.nan, 0.0, 1.0]
+        np.testing.assert_array_equal(primitive_func(x), answers)
 
     def test_with_featuretools(self, es):
         transform, aggregation = find_applicable_primitives(self.primitive)

--- a/nlp_primitives/tests/test_title_word_count.py
+++ b/nlp_primitives/tests/test_title_word_count.py
@@ -19,14 +19,14 @@ class TestTitleWordCount(PrimitiveT):
         )
         primitive_func = self.primitive().get_function()
         answers = [2.0, 0.0, 1.0, 2.0]
-        np.testing.assert_array_equal(answers, primitive_func(x)) 
-    
+        np.testing.assert_array_equal(answers, primitive_func(x))
+
     def test_nan(self):
         x = pd.Series([np.nan, "", "My favorite movie is Jaws."])
         primitive_func = self.primitive().get_function()
         answers = [np.nan, 0.0, 2.0]
-        np.testing.assert_array_equal(answers, primitive_func(x)) 
-    
+        np.testing.assert_array_equal(answers, primitive_func(x))
+
     def test_with_featuretools(self, es):
         transform, aggregation = find_applicable_primitives(self.primitive)
         primitive_instance = self.primitive()

--- a/nlp_primitives/tests/test_title_word_count.py
+++ b/nlp_primitives/tests/test_title_word_count.py
@@ -18,15 +18,15 @@ class TestTitleWordCount(PrimitiveT):
             ]
         )
         primitive_func = self.primitive().get_function()
-        answers = pd.Series([2.0, 0.0, 1.0, 2.0])
-        pd.testing.assert_series_equal(primitive_func(x), answers, check_names=False)
-
+        answers = [2.0, 0.0, 1.0, 2.0]
+        np.testing.assert_array_equal(answers, primitive_func(x)) 
+    
     def test_nan(self):
         x = pd.Series([np.nan, "", "My favorite movie is Jaws."])
         primitive_func = self.primitive().get_function()
-        answers = pd.Series([np.nan, 0.0, 2.0])
-        pd.testing.assert_series_equal(primitive_func(x), answers, check_names=False)
-
+        answers = [np.nan, 0.0, 2.0]
+        np.testing.assert_array_equal(answers, primitive_func(x)) 
+    
     def test_with_featuretools(self, es):
         transform, aggregation = find_applicable_primitives(self.primitive)
         primitive_instance = self.primitive()

--- a/nlp_primitives/tests/test_upper_case_count.py
+++ b/nlp_primitives/tests/test_upper_case_count.py
@@ -4,7 +4,6 @@ import pandas as pd
 from ..upper_case_count import UpperCaseCount
 from .test_utils import PrimitiveT, find_applicable_primitives, valid_dfs
 
-
 class TestUpperCaseCount(PrimitiveT):
     primitive = UpperCaseCount
 
@@ -13,14 +12,14 @@ class TestUpperCaseCount(PrimitiveT):
             ["This IS a STRING.", "Testing AaA", "Testing AAA-BBB", "testing aaa"]
         )
         primitive_func = self.primitive().get_function()
-        answers = pd.Series([9.0, 3.0, 7.0, 0.0])
-        pd.testing.assert_series_equal(primitive_func(x), answers, check_names=False)
+        answers = [9.0, 3.0, 7.0, 0.0]
+        np.testing.assert_array_equal(primitive_func(x), answers)
 
     def test_nan(self):
         x = pd.Series([np.nan, "", "This IS a STRING."])
         primitive_func = self.primitive().get_function()
-        answers = pd.Series([np.nan, 0.0, 9.0])
-        pd.testing.assert_series_equal(primitive_func(x), answers, check_names=False)
+        answers = [np.nan, 0.0, 9.0]
+        np.testing.assert_array_equal(primitive_func(x), answers)
 
     def test_with_featuretools(self, es):
         transform, aggregation = find_applicable_primitives(self.primitive)

--- a/nlp_primitives/tests/test_upper_case_count.py
+++ b/nlp_primitives/tests/test_upper_case_count.py
@@ -4,6 +4,7 @@ import pandas as pd
 from ..upper_case_count import UpperCaseCount
 from .test_utils import PrimitiveT, find_applicable_primitives, valid_dfs
 
+
 class TestUpperCaseCount(PrimitiveT):
     primitive = UpperCaseCount
 

--- a/nlp_primitives/title_word_count.py
+++ b/nlp_primitives/title_word_count.py
@@ -25,7 +25,7 @@ class TitleWordCount(CountString):
 
     name = "title_word_count"
     input_types = [ColumnSchema(logical_type=NaturalLanguage)]
-    return_type = ColumnSchema(logical_type=Double, semantic_tags={"numeric"})
+    return_type = ColumnSchema(logical_type=IntegerNullable, semantic_tags={"numeric"})
     default_value = 0
 
     def __init__(self):

--- a/nlp_primitives/title_word_count.py
+++ b/nlp_primitives/title_word_count.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-import numpy as np
 from featuretools.primitives.base import TransformPrimitive
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Double, NaturalLanguage
+from .count_string import CountString 
 
-
-class TitleWordCount(TransformPrimitive):
+class TitleWordCount(CountString):
     """Determines the number of title words in a string.
 
     Description:
@@ -24,18 +23,9 @@ class TitleWordCount(TransformPrimitive):
     """
 
     name = "title_word_count"
-    input_types = [ColumnSchema(logical_type=NaturalLanguage)]
-    return_type = ColumnSchema(logical_type=Double, semantic_tags={"numeric"})
     default_value = 0
 
-    def get_function(self):
+    def __init__(self):
         pattern = r"([A-Z][^\s]*)"
+        super().__init__(string=pattern, is_regex=True, ignore_case=False) 
 
-        def title_word_count(x):
-            x = x.reset_index(drop=True)
-            counts = x.str.extractall(pattern).groupby(level=0).count()[0]
-            counts = counts.reindex_like(x).fillna(0)
-            counts[x.isnull()] = np.nan
-            return counts.astype(float)
-
-        return title_word_count

--- a/nlp_primitives/title_word_count.py
+++ b/nlp_primitives/title_word_count.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from woodwork.column_schema import ColumnSchema
-from woodwork.logical_types import Double, NaturalLanguage
+from woodwork.logical_types import IntegerNullable, NaturalLanguage
 
 from .count_string import CountString
 

--- a/nlp_primitives/title_word_count.py
+++ b/nlp_primitives/title_word_count.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from featuretools.primitives.base import TransformPrimitive
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Double, NaturalLanguage
-from .count_string import CountString 
+
+from .count_string import CountString
+
 
 class TitleWordCount(CountString):
     """Determines the number of title words in a string.
@@ -23,9 +24,10 @@ class TitleWordCount(CountString):
     """
 
     name = "title_word_count"
+    input_types = [ColumnSchema(logical_type=NaturalLanguage)]
+    return_type = ColumnSchema(logical_type=Double, semantic_tags={"numeric"})
     default_value = 0
 
     def __init__(self):
         pattern = r"([A-Z][^\s]*)"
-        super().__init__(string=pattern, is_regex=True, ignore_case=False) 
-
+        super().__init__(string=pattern, is_regex=True, ignore_case=False)

--- a/nlp_primitives/upper_case_count.py
+++ b/nlp_primitives/upper_case_count.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-import numpy as np
+from .count_string import CountString
 from featuretools.primitives.base import TransformPrimitive
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Double, NaturalLanguage
 
 
-class UpperCaseCount(TransformPrimitive):
+class UpperCaseCount(CountString):
     """Calculates the number of upper case letters in text.
 
     Description:
@@ -27,14 +27,6 @@ class UpperCaseCount(TransformPrimitive):
     return_type = ColumnSchema(logical_type=Double, semantic_tags={"numeric"})
     default_value = 0
 
-    def get_function(self):
+    def __init__(self):
         pattern = r"([A-Z])"
-
-        def upper_case_count(x):
-            x = x.reset_index(drop=True)
-            counts = x.str.extractall(pattern).groupby(level=0).count()[0]
-            counts = counts.reindex_like(x).fillna(0)
-            counts[x.isnull()] = np.nan
-            return counts.astype(float)
-
-        return upper_case_count
+        super().__init__(string=pattern, is_regex=True, ignore_case=False)

--- a/nlp_primitives/upper_case_count.py
+++ b/nlp_primitives/upper_case_count.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from .count_string import CountString
-from featuretools.primitives.base import TransformPrimitive
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Double, NaturalLanguage
+
+from .count_string import CountString
 
 
 class UpperCaseCount(CountString):

--- a/nlp_primitives/upper_case_count.py
+++ b/nlp_primitives/upper_case_count.py
@@ -24,7 +24,7 @@ class UpperCaseCount(CountString):
 
     name = "upper_case_count"
     input_types = [ColumnSchema(logical_type=NaturalLanguage)]
-    return_type = ColumnSchema(logical_type=Double, semantic_tags={"numeric"})
+    return_type = ColumnSchema(logical_type=IntegerNullable, semantic_tags={"numeric"})
     default_value = 0
 
     def __init__(self):

--- a/nlp_primitives/upper_case_count.py
+++ b/nlp_primitives/upper_case_count.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from woodwork.column_schema import ColumnSchema
-from woodwork.logical_types import Double, NaturalLanguage
+from woodwork.logical_types import IntegerNullable, NaturalLanguage
 
 from .count_string import CountString
 


### PR DESCRIPTION
- Fixes #181 
- Refactors `TitleWordCount`, `PunctuationCount`, `UpperCaseCount` to use `count_string`