### PR TITLE
Fix handling of all-whitespace strings in `MeanCharactersPerSentence`

### DIFF
--- a/nlp_primitives/mean_characters_per_sentence.py
+++ b/nlp_primitives/mean_characters_per_sentence.py
@@ -33,9 +33,7 @@ class MeanCharactersPerSentence(TransformPrimitive):
                 return np.nan
             if not len(sentences := sent_tokenize(text)):
                 return 0.0
-            total = 0.0
-            for s in sentences:
-                total += len(s)
+            total = sum(len(s) for s in sentences)
             return total / len(sentences)
 
         def mean_characters_per_sentence(array):

--- a/nlp_primitives/mean_characters_per_sentence.py
+++ b/nlp_primitives/mean_characters_per_sentence.py
@@ -31,9 +31,7 @@ class MeanCharactersPerSentence(TransformPrimitive):
         def _mean_characters_per_sentence(text):
             if not isinstance(text, str):
                 return np.nan
-            if len(text) == 0:
-                return 0.0
-            if not sentences := sent_tokenize(text):
+            if not len(sentences := sent_tokenize(text)):
                 return 0.0
             total = 0.0
             for s in sentences:

--- a/nlp_primitives/mean_characters_per_sentence.py
+++ b/nlp_primitives/mean_characters_per_sentence.py
@@ -32,8 +32,9 @@ class MeanCharactersPerSentence(TransformPrimitive):
             if not isinstance(text, str):
                 return np.nan
             if len(text) == 0:
-                return 0
-            sentences = sent_tokenize(text)
+                return 0.0
+            if not sentences := sent_tokenize(text):
+                return 0.0
             total = 0.0
             for s in sentences:
                 total += len(s)

--- a/nlp_primitives/mean_characters_per_sentence.py
+++ b/nlp_primitives/mean_characters_per_sentence.py
@@ -31,7 +31,8 @@ class MeanCharactersPerSentence(TransformPrimitive):
         def _mean_characters_per_sentence(text):
             if not isinstance(text, str):
                 return np.nan
-            if not len(sentences := sent_tokenize(text)):
+            sentences = sent_tokenize(text)
+            if not len(sentences):
                 return 0.0
             total = sum(len(s) for s in sentences)
             return total / len(sentences)

--- a/nlp_primitives/tests/test_mean_characters_per_sentence.py
+++ b/nlp_primitives/tests/test_mean_characters_per_sentence.py
@@ -35,7 +35,7 @@ class TestMeanCharactersPerSentence(PrimitiveT):
         "na_value",
         [None, np.nan, pd.NA],
     )
-    def test_nans(self, na_value):
+    def test_nans_and_empty(self, na_value):
         x = pd.Series([na_value, "", "         ", "third line"])
         primitive_func = self.primitive().get_function()
         answers = pd.Series([np.nan, 0, 0, 10.0])

--- a/nlp_primitives/tests/test_mean_characters_per_sentence.py
+++ b/nlp_primitives/tests/test_mean_characters_per_sentence.py
@@ -36,9 +36,9 @@ class TestMeanCharactersPerSentence(PrimitiveT):
         [None, np.nan, pd.NA],
     )
     def test_nans(self, na_value):
-        x = pd.Series([na_value, "", "third line"])
+        x = pd.Series([na_value, "", "         ", "third line"])
         primitive_func = self.primitive().get_function()
-        answers = pd.Series([np.nan, 0, 10.0])
+        answers = pd.Series([np.nan, 0, 0, 10.0])
         pd.testing.assert_series_equal(primitive_func(x), answers, check_names=False)
 
     @pytest.mark.parametrize(

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -8,6 +8,7 @@ Future Release
         * Add conda create feedstock pull request workflow (:pr:`220`)
         * Improve ``PartOfSpeech`` docstring (:pr:`224`)
     * Fixes
+        * Fix handling of all-whitepace strings in ``MeanCharactersPerSentence`` (:pr:`234`)
     * Changes
         * Update workflow_dispatch to release workflow (:pr:`221`)
     * Documentation Changes


### PR DESCRIPTION
- closes #232 